### PR TITLE
moving rxjs to an external

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,11 @@ module.exports = webpackConfigEnv => {
     webpackConfigEnv
   });
 
-  return webpackMerge.smart(defaultConfig, {
+  const rxjsExternals = {
+    externals: [/^rxjs\/?.*$/]
+  };
+
+  return webpackMerge.smart(defaultConfig, rxjsExternals, {
     module: {
       rules: [
         {


### PR DESCRIPTION
Relies on https://github.com/react-microfrontends/shared-dependencies/pull/2