### PR TITLE
adding films as a code split item

### DIFF
--- a/src/react-mf-people.js
+++ b/src/react-mf-people.js
@@ -2,14 +2,23 @@ import "./set-public-path";
 import React from "react";
 import ReactDOM from "react-dom";
 import singleSpaReact from "single-spa-react";
-import Root from "./root.component";
 
 const lifecycles = singleSpaReact({
   React,
   ReactDOM,
-  rootComponent: Root
+  loadRootComponent: () =>
+    import(
+      /* webpackChunkName: "people-root-component" */ "./root.component.js"
+    ).then(mod => mod.default)
 });
 
 export const bootstrap = lifecycles.bootstrap;
 export const mount = lifecycles.mount;
 export const unmount = lifecycles.unmount;
+
+export function getFilmsComponent() {
+  return () =>
+    import(
+      /* webpackChunkName: "films-component" */ "./films/film.component.js"
+    ).then(mod => mod.default);
+}


### PR DESCRIPTION
Splitting out films and exporting it so it can be shared easier. I'm debating on moving it into the styleguide but I'm not sure that's the best place for it.

My goal is to show off sharing a component from a module that isn't the styleguide. I don't think this is ultimately the best example because films isn't tightly coupled to People.

Options: 
- Don't do this at all
- Do this as an interim step to something better (maybe a films microservice)
- Do this and call it a day