### PR TITLE
changing routing to use a subroute instead of a queryparam

### DIFF
--- a/src/people-list/people-list.component.js
+++ b/src/people-list/people-list.component.js
@@ -1,9 +1,8 @@
 import React, { Fragment } from "react";
 import { getPeople } from "../utils/api.js";
-import { Link, useRouteMatch } from "react-router-dom";
+import { Link } from "react-router-dom";
 
 export default function PeopleList({ people, loadingPeople, selectPerson }) {
-  const match = useRouteMatch();
   return (
     <div>
       <Fragment>
@@ -18,9 +17,7 @@ export default function PeopleList({ people, loadingPeople, selectPerson }) {
             <Link
               key={person.name}
               className={`h-12 flex items-center ${borderClass} border-white cursor-pointer no-underline`}
-              to={`${match.path}?selected=${window.encodeURIComponent(
-                person.id
-              )}`}
+              to={`/people/${window.encodeURIComponent(person.id)}`}
             >
               {person.name}
             </Link>

--- a/src/people-page/people-page.component.js
+++ b/src/people-page/people-page.component.js
@@ -14,6 +14,9 @@ const initialState = {
 };
 
 export default function PeoplePage(props) {
+  const { match } = props;
+  const { params = {} } = match;
+  const { personId } = params;
   const [state, dispatch] = React.useReducer(reducer, initialState);
 
   const { nextPage, loadingPeople, people, selectedPerson, pageNum } = state;
@@ -36,21 +39,16 @@ export default function PeoplePage(props) {
   }, [pageNum, nextPage, loadingPeople]);
 
   React.useEffect(() => {
-    const search = props.location.search;
-    const parsed = queryString.parse(search);
-
     if (
-      (state.selectedPerson === undefined && parsed.selected !== undefined) ||
-      (state.selectedPerson &&
-        parsed &&
-        parsed.selected !== state.selectedPerson.id)
+      (state.selectedPerson === undefined && personId !== undefined) ||
+      (state.selectedPerson && personId !== state.selectedPerson.id)
     ) {
-      const person = state.people.find(p => p.id === parsed.selected);
+      const person = state.people.find(p => p.id === personId);
       if (person) {
         dispatch({ type: "selectPerson", person });
       }
     }
-  }, [props.location.search, state.selectedPerson, state.people]);
+  }, [state.people, state.selectedPerson, personId]);
 
   return (
     <div>

--- a/src/root.component.js
+++ b/src/root.component.js
@@ -17,7 +17,10 @@ export default class Root extends React.Component {
     ) : (
       <div className="mt-16">
         <BrowserRouter>
-          <Route path="/people" component={PeoplePage} />
+          <Switch>
+            <Route path="/people/:personId" component={PeoplePage} />
+            <Route path="/people" component={PeoplePage} />
+          </Switch>
         </BrowserRouter>
       </div>
     );


### PR DESCRIPTION
Moving from `/people?selected=1` to `/people/1` just like how planets does it.

This fixes a bug where linking from planets to a person wouldn't automatically select the person.

